### PR TITLE
fix: Space enough for message content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+### Fixed
+- Allow message content to be more than 255 chars.
+
 ## [0.1.0] – 2024-04-18
 
 ### Added

--- a/database/migrations/2024_06_13_120000_ragnarok_strex_resize_content.php
+++ b/database/migrations/2024_06_13_120000_ragnarok_strex_resize_content.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('strex_transactions', function (Blueprint $table) {
+            $table->text('message_content')->nullable()->comment('Actual SMS sent to recipient')->change();
+        });
+    }
+};


### PR DESCRIPTION
This fixes the import error on too long messages `strex_transactions.message_content`